### PR TITLE
Handle more syntax.

### DIFF
--- a/format/src/main/scala/org/scalafmt/internal/TokenOps.scala
+++ b/format/src/main/scala/org/scalafmt/internal/TokenOps.scala
@@ -21,6 +21,7 @@ object TreeOps {
         _: Type.Select | _: Term.Super | _: Term.This | _: Pat.Var |
         _: Pat.Tuple | _: PatName | _: Pat.Extract | _: Term.Placeholder | _: Pat.Wildcard =>
       false
+    case t: Term.New => t.init.argss.isEmpty
     case _ => true
   }
 

--- a/format/src/test/scala/org/scalafmt/internal/IdempotencyPropertyTest.scala
+++ b/format/src/test/scala/org/scalafmt/internal/IdempotencyPropertyTest.scala
@@ -21,7 +21,7 @@ class IdempotencyPropertyTest extends BaseScalaPrinterTest {
   test("AST is unchanged") {
     val corpus = Corpus
       .files(Corpus.fastparse)
-      .take(4000) // take files as you please.
+      .take(7000) // take files as you please.
       .toBuffer
       .par
     val nonEmptyDiff = SyntaxAnalysis.run[Unit](corpus) { file =>
@@ -31,14 +31,15 @@ class IdempotencyPropertyTest extends BaseScalaPrinterTest {
         val tree = in.parse[Source].get
         val formatted = Format.format(in)
         val tree2 = formatted.parse[Source].get
-        if (StructurallyEqual(tree, tree2).isRight) Nil
+        val treeNorm = normalize(tree)
+        val tree2Norm = normalize(tree2)
+        if (StructurallyEqual(treeNorm, tree2Norm).isRight) Nil
         else {
-          val diff = getDiff(file.jFile.getAbsolutePath, tree, tree2)
+          val diff = getDiff(file.jFile.getAbsolutePath, treeNorm, tree2Norm)
           if (diff.nonEmpty) {
             logger.elem(diff)
             () :: Nil
-          }
-          else Nil
+          } else Nil
         }
       } catch {
         case NonFatal(e) =>

--- a/format/src/test/scala/org/scalafmt/internal/ScalaPrinterTest.scala
+++ b/format/src/test/scala/org/scalafmt/internal/ScalaPrinterTest.scala
@@ -17,7 +17,8 @@ class ScalaPrinterTest extends BaseScalaPrinterTest {
   check("var a = 1")
   check("def a = 1")
   check("def a(b: B) = 1")
-  check("def a[A](b: B) = 1")
+  check("def a[A](b: B = c) = 1")
+  check("def a(implicit b: B, c: C) = b")
   check("val a: Int = 1")
   check("var a: Int = 1")
   check("def a: Int = 1")
@@ -104,7 +105,7 @@ class ScalaPrinterTest extends BaseScalaPrinterTest {
   checkEnumerator("`a` <- b")
   checkEnumerator("a <- b")
   checkEnumerator("a = b")
-  checkCase("case `elem` :: _ =>")
+  checkCase("case `a` :: `b` :: _ =>")
 
   // term
   check("'c'")
@@ -179,6 +180,7 @@ class ScalaPrinterTest extends BaseScalaPrinterTest {
       |} yield a""".stripMargin
   )
   check("try a catch b")
+  check("try a finally b()")
   check("try a catch { case _: A => } finally c")
   check("a match { case 1 => }")
   check("(if (a) b else c) match { case 1 => }")
@@ -254,6 +256,39 @@ class ScalaPrinterTest extends BaseScalaPrinterTest {
   check("a { b => implicit c => d }")
   check("a { implicit b => implicit c => d }")
   check("""a("\\n")""")
+  check("""a("[\" \\u00e4\\u00e4li\\u00f6t\"]") """.stripMargin)
+  check("""
+          |a(
+          |  b,
+          |  { implicit c =>
+          |    d
+          |
+          |    e
+          |  }
+          |)
+        """.stripMargin)
+  check(
+    """
+      |a {
+      |  b
+      |
+      |  c
+      |}
+    """.stripMargin)
+  check(
+    """
+      |if (a)
+      |  b
+      |else if (c)
+      |  d
+      |else {
+      |  a
+      |
+      |  b
+      |}
+    """.stripMargin)
+  check("(new A).a")
+  check("new A().a")
 
   // infix precedence/associativity
   check("(a :!= b) == c")


### PR DESCRIPTION
I discovered a lot of problems by manually inspecting diffs from running on large projects. IdempotencyTest currently ignores parse errors on formatted output, which gave me overconfidence in the correctness of the output.