### PR TITLE
Cover more syntax

### DIFF
--- a/format/src/test/scala/org/scalafmt/internal/BaseScalaPrinterTest.scala
+++ b/format/src/test/scala/org/scalafmt/internal/BaseScalaPrinterTest.scala
@@ -73,6 +73,7 @@ abstract class BaseScalaPrinterTest extends DiffSuite {
     import scala.meta._
 
     val transform: PartialFunction[Tree, Tree] = {
+      case Term.Block(a :: Nil) => a
       case Term.ApplyInfix(lhs, op, targs, args) =>
         if (targs.isEmpty) q"$lhs.$op(..$args)"
         else q"$lhs.$op[..$targs](..$args)"
@@ -84,7 +85,7 @@ abstract class BaseScalaPrinterTest extends DiffSuite {
     }
 
     override def apply(tree: Tree): Tree = {
-      super.apply(transform.lift(tree).getOrElse(tree))
+      super.apply(transform.lift(tree).map(this.apply).getOrElse(tree))
     }
   }
 

--- a/format/src/test/scala/org/scalafmt/internal/ScalaPrinterTest.scala
+++ b/format/src/test/scala/org/scalafmt/internal/ScalaPrinterTest.scala
@@ -106,6 +106,7 @@ class ScalaPrinterTest extends BaseScalaPrinterTest {
   checkEnumerator("a <- b")
   checkEnumerator("a = b")
   checkCase("case `a` :: `b` :: _ =>")
+  checkCase(""" case a b `c` =>""")
 
   // term
   check("'c'")
@@ -160,7 +161,9 @@ class ScalaPrinterTest extends BaseScalaPrinterTest {
   check("a op[T] b")
   check("a(b => c)")
   check("a((b: B) => c)")
+  check("a(() => b)")
   check("a { case 1 => }")
+    check("forAll { (f: Long => Long) => a }")
   check(
     """a {
       |  case 1 =>
@@ -289,6 +292,9 @@ class ScalaPrinterTest extends BaseScalaPrinterTest {
     """.stripMargin)
   check("(new A).a")
   check("new A().a")
+  check("a(_ => b)")
+  check("a { _: B => b }")
+  check("a { b: B => b }")
 
   // infix precedence/associativity
   check("(a :!= b) == c")
@@ -313,4 +319,7 @@ class ScalaPrinterTest extends BaseScalaPrinterTest {
   check("(a /: b) to 5")
   check("r /: (1 to 5)")
   check("a(b :: (c d e):_*)")
+  check("(a := b) op c")
+  check("a t_= (a b c)")
+  check("(a b c) +: d")
 }


### PR DESCRIPTION
- Use scalameta infix operator precedence, which handles inconsistencies
  between the language spec and scalac implementation.
- handle more cases for Term.Param