### PR TITLE
Fixup README formarting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Improves the built-in Scalameta pretty printer (`Tree.syntax`) with the followin
 * [X] Line Wrapping: large expressions don't appear in a single line with hundreds of columns.
 * [ ] Better Performance
 
-The end goal of this project is to enable a more powerful refactoring API for[Scalafix](https://scalacenter.github.io/scalafix/).
+The end goal of this project is to enable a more powerful refactoring API for [Scalafix](https://scalacenter.github.io/scalafix/).
 Currently, Scalafix rewrites are implemented using a fairly low-level token API, which is error-prone.
 
 ## Team
 
 The current maintainers (people who can merge pull requests) are:
 
-- Guillaume Massé - [`@MasseGuillaume`](https://github.com/@MasseGuillaume)
+- Guillaume Massé - [`@MasseGuillaume`](https://github.com/MasseGuillaume)
 - Ólafur Páll Geirsson - [`@olafurpg`](https://github.com/olafurpg)


### PR DESCRIPTION
Add a space, remove an at.