### PR TITLE
Fixed None.get

### DIFF
--- a/format/src/main/scala/scala/meta/internal/prettyprinters/tokens/SyntaxTokensUtils.scala
+++ b/format/src/main/scala/scala/meta/internal/prettyprinters/tokens/SyntaxTokensUtils.scala
@@ -91,8 +91,9 @@ object SyntaxTokensUtils {
         elems
           .sliding(2, 1)
           .map {
-            case List(l, r) => tree.findBetween[Comma](_ => l, _ => r).get
+            case List(l, r) => tree.findBetween[Comma](_ => l, _ => r)
           }
+          .collect { case Some(t) => t }
           .toList
     }
   }


### PR DESCRIPTION
I've been starting to use this library (built from sources, I'm very aware it's experimental) for code generation, and encountered this bug. 